### PR TITLE
Fix compiler warning in Amalgam.cpp

### DIFF
--- a/src/Amalgam/Amalgam.cpp
+++ b/src/Amalgam/Amalgam.cpp
@@ -138,8 +138,8 @@ void Amalgam::process(const ProcessArgs &args) {
     _mm_storeu_ps(andOut, __xyAnd);
     _mm_storeu_ps(xorOut, __xyXor);
 
-    zAnd = (zOut[0] > 0.f) & (zOut[2] > 0.f) ? 5.f : 0.f;
-    zXor = (zOut[0] > 0.f) ^ (zOut[2] > 0.f) ? 5.f : 0.f;
+    zAnd = ((zOut[0] > 0.f) & (zOut[2] > 0.f)) ? 5.f : 0.f;
+    zXor = ((zOut[0] > 0.f) ^ (zOut[2] > 0.f)) ? 5.f : 0.f;
     zAndDCFilter.input = zAnd;
     zXorDCFilter.input = zXor;
     zAndDCFilter.process();


### PR DESCRIPTION
Detected by macOS clang.
```
ValleyAudio/src/Amalgam/Amalgam.cpp:141:46: error: operator '?:' has lower precedence than '&'; '&' will be evaluated first [-Werror,-Wbitwise-conditional-parentheses]
    zAnd = (zOut[0] > 0.f) & (zOut[2] > 0.f) ? 5.f : 0.f;
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^
ValleyAudio/src/Amalgam/Amalgam.cpp:141:46: note: place parentheses around the '&' expression to silence this warning
    zAnd = (zOut[0] > 0.f) & (zOut[2] > 0.f) ? 5.f : 0.f;
                                             ^
           (                                )
ValleyAudio/src/Amalgam/Amalgam.cpp:141:46: note: place parentheses around the '?:' expression to evaluate it first
    zAnd = (zOut[0] > 0.f) & (zOut[2] > 0.f) ? 5.f : 0.f;
                                             ^
                             (                          )
```
