### PR TITLE
Add Cardinal specific changes

### DIFF
--- a/src/Terrorform/Terrorform.hpp
+++ b/src/Terrorform/Terrorform.hpp
@@ -839,7 +839,9 @@ struct TerrorformWidget : ModuleWidget {
     void step() override;
     void changeDisplayStyle();
     void exportWavetables();
+    void exportWavetablesPathSelected(char* path);
     void importWavetables();
+    void importWavetablesPathSelected(char* path);
 };
 
 #endif

--- a/src/Terrorform/TerrorformWaveTableEditor.hpp
+++ b/src/Terrorform/TerrorformWaveTableEditor.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "../Valley.hpp"
 #include "../ValleyComponents.hpp"
+#include "../Common/Utilities.hpp"
 #include "WavetableEditor/MenuBase.hpp"
 #include "WavetableEditor/TFormEditorButton.hpp"
 #include "WavetableEditor/TFormEditorGrid.hpp"
@@ -19,10 +20,11 @@ struct TFormEditorBankEditMenu : OpaqueWidget {
     TFormCloneMenu* cloneMenu;
     TFormMoveMenu* moveMenu;
     TFormClearMenu* clearMenu;
+    std::string dir;
     std::shared_ptr<int> selectedBank;
     std::vector<bool> slotFilled;
 
-    std::function<std::shared_ptr<std::vector<float>>()> onLoadWAVCallback;
+    std::function<std::shared_ptr<std::vector<float>>(char* path)> onLoadWAVCallback;
     std::function<void(int, TerrorformWaveBank&)> onGetBankCallback;
 
     TFormEditorBankEditMenu();
@@ -79,7 +81,7 @@ struct TFormEditor : OpaqueWidget {
 
     TFormEditor();
     void addOnExitCallback(const std::function<void()>& onExitCallback);
-    void addLoadWAVCallback(const std::function<std::shared_ptr<std::vector<float>>()>& onLoadWAVCallback);
+    void addLoadWAVCallback(const std::function<std::shared_ptr<std::vector<float>>(char* path)>& onLoadWAVCallback);
     void addIngestTableCallback(const std::function<void(int, int, int, int, const std::string&)>& onIngestTableCallback);
     void addClearBankCallback(const std::function<void(int)>& onClearBankCallback);
     void addCloneBankCallback(const std::function<void(int, int, int, int)>& onCloneBankCallback);


### PR DESCRIPTION
Hi there.

This PR adds the necessary changes to make the Terrorform `osdialog` usage work within [Cardinal](https://github.com/DISTRHO/Cardinal).
Since `osdialog` calls are blocking, Cardinal does not use it (it is in my opinion very bad practice for plugins to block the main event loop).

Changes to the code are made in a way that compatibility with regular Rack remains intact.
I tried to change things as little as possible, the part about `onLoadWAVCallback` was an odd one due to it expecting a blocking operation.
Hopefully all still makes sense in the end.
Let me know if you have any questions.

