### PR TITLE
Fix some unitialized variables

### DIFF
--- a/src/Common/DSP/DLFO.hpp
+++ b/src/Common/DSP/DLFO.hpp
@@ -22,6 +22,8 @@ public:
         _b = 0.405284735;
         setSampleRate(44100.f);
         setFrequency(0.75f);
+        _syncHigh = false;
+        _triggerHigh = false;
         _shTriggered = false;
         out[SH_WAVE] = _noise.getValue();
     }

--- a/src/Common/SIMD/VecOnePoleFilters.cpp
+++ b/src/Common/SIMD/VecOnePoleFilters.cpp
@@ -1,6 +1,7 @@
 #include "VecOnePoleFilters.hpp"
 
 VecOnePoleLPFilter::VecOnePoleLPFilter() {
+    _cutoffFreq = 0.f;
     setSampleRate(44100.f);
     setCutoffFreq(_sampleRate / 2.f);
     clear();
@@ -67,6 +68,7 @@ float VecOnePoleLPFilter::getMaxCutoffFreq() const {
 ///////////////////////////////////////////////////////////////////////////////
 
 VecOnePoleHPFilter::VecOnePoleHPFilter() {
+    _cutoffFreq = 0.f;
     setSampleRate(44100.f);
     setCutoffFreq(_sampleRate / 2.f);
     clear();


### PR DESCRIPTION
Detected by valgrind, there are more but want to check your interest on them.
Should I send more patches?

On the LFO there is simply the case of some variables not always being defined at the start, which leads to some initial undefined behaviour.
For the filters, `_cutoffFreq` is simply not initialized yet when the first `setSampleRate` is called. Also triggering undefined behaviour.

The reports from valgrind:
```
==1209673== Conditional jump or move depends on uninitialised value(s)
==1209673==    at 0x183909F: DLFO::sync(float) (DLFO.hpp:82)
==1209673==    by 0x18320C0: Interzone::process(rack::engine::Module::ProcessArgs const&) (Interzone.cpp:151)
==1209673==    by 0x1B152D5: rack::engine::Module::doProcess(rack::engine::Module::ProcessArgs const&) (Module.cpp:345)
==1209673==    by 0x1A3FC4C: rack::engine::Engine_stepFrame(rack::engine::Engine*) (Engine.cpp:254)
==1209673==    by 0x1A4095C: rack::engine::Engine::stepBlock(int) (Engine.cpp:415)

==1209673== Conditional jump or move depends on uninitialised value(s)
==1209673==    at 0x183911B: DLFO::trigger(float) (DLFO.hpp:92)
==1209673==    by 0x18320FB: Interzone::process(rack::engine::Module::ProcessArgs const&) (Interzone.cpp:152)
==1209673==    by 0x1B152D5: rack::engine::Module::doProcess(rack::engine::Module::ProcessArgs const&) (Module.cpp:345)
==1209673==    by 0x1A3FC4C: rack::engine::Engine_stepFrame(rack::engine::Engine*) (Engine.cpp:254)
==1209673==    by 0x1A4095C: rack::engine::Engine::stepBlock(int) (Engine.cpp:415)

...

==1209673== Conditional jump or move depends on uninitialised value(s)
==1209673==    at 0x1889BA8: VecOnePoleLPFilter::setCutoffFreq(float) (VecOnePoleFilters.cpp:37)
==1209673==    by 0x1889B26: VecOnePoleLPFilter::setSampleRate(float) (VecOnePoleFilters.cpp:28)
==1209673==    by 0x1889999: VecOnePoleLPFilter::VecOnePoleLPFilter() (VecOnePoleFilters.cpp:4)
==1209673==    by 0x182DA1D: Interzone::Interzone() (Interzone.cpp:3)

==1209673== Conditional jump or move depends on uninitialised value(s)
==1209673==    at 0x188A200: VecOnePoleHPFilter::setCutoffFreq(float) (VecOnePoleFilters.cpp:100)
==1209673==    by 0x188A1D6: VecOnePoleHPFilter::setSampleRate(float) (VecOnePoleFilters.cpp:96)
==1209673==    by 0x1889FE9: VecOnePoleHPFilter::VecOnePoleHPFilter() (VecOnePoleFilters.cpp:70)
==1209673==    by 0x1839177: VecDirectOsc::VecDirectOsc() (VecDirectOsc.hpp:6)
==1209673==    by 0x182DA49: Interzone::Interzone() (Interzone.cpp:3)

```