### PR TITLE
Fix TriSawLFO output exceeding 1.0 if revPoint is modulated.

### DIFF
--- a/src/Common/DSP/LFO.hpp
+++ b/src/Common/DSP/LFO.hpp
@@ -72,7 +72,6 @@ public:
         _output = 0.0;
         _sampleRate = sampleRate;
         _step = 0.0;
-        _rising = true;
         setFrequency(frequency);
         setRevPoint(0.5);
     }
@@ -80,14 +79,9 @@ public:
     double process() {
         if(_step > 1.0) {
             _step -= 1.0;
-            _rising = true;
         }
 
-        if(_step >= _revPoint) {
-            _rising = false;
-        }
-
-        if(_rising) {
+        if(_step < _revPoint) {
             _output = _step * _riseRate;
         }
         else {
@@ -104,14 +98,9 @@ public:
         for (uint64_t i = 0; i < blockSize; ++i) {
             if(_step > 1.0) {
                 _step -= 1.0;
-                _rising = true;
             }
 
-            if(_step >= _revPoint) {
-                _rising = false;
-            }
-
-            if(_rising) {
+            if(_step < _revPoint) {
                 _output = _step * _riseRate;
             }
             else {
@@ -166,7 +155,6 @@ private:
     double _fallRate;
     double _step;
     double _stepSize;
-    bool _rising;
 
     void calcStepSize() {
         _stepSize = _frequency / _sampleRate;


### PR DESCRIPTION
This is a bugfix. I found in my Rust reimplementation of this TriSawLFO algorithm,
that if the revPoint is changed while the LFO is in rising or falling state,
the output values could easily exceed 1.0. The bug emits from the
desync of the internal _rising flag and the actual state of _step.

Given _rising = false (once LFO _step passed revPoint), if the revPoint
is changed with setRevPoint(), _fallRate could become eg. -999.
When the next LFO output is calculated with _rising = false and _fallRate=-999,
the output would be eg. 0.6 * -999.0 - -999.0 = 399.6

This patch gets rid of _rising and reduces two if statements to one.