### PR TITLE
Fix uninitialised values and memory leaks

### DIFF
--- a/src/Amalgam/VecAmalgam.cpp
+++ b/src/Amalgam/VecAmalgam.cpp
@@ -79,7 +79,6 @@ void VecAmalgam::setMode(int mode) {
 void VecAmalgam::setSampleRate(float sampleRate) {
     _engineSampleRate = sampleRate;
     _quarterNyquist = _engineSampleRate / 32.f;
-    calcStepSize();
 }
 
 void VecAmalgam::calcStepSize() {

--- a/src/Common/SIMD/QuadOsc.cpp
+++ b/src/Common/SIMD/QuadOsc.cpp
@@ -413,8 +413,8 @@ QuadOsc::QuadOsc() {
     __b = __zeros;
     __readPhase = __zeros;
     __dir = __ones;
+    _syncMode = 0;
     setFrequency(1.f);
-    setSyncMode(0);
     setShapeMethod(0);
     _shaper.setShapeMode(0);
 }

--- a/src/Dexter/Dexter.cpp
+++ b/src/Dexter/Dexter.cpp
@@ -1055,33 +1055,27 @@ DexterWidget::DexterWidget(Dexter *module) {
     for(auto op = 0; op < kNumOperators; ++op) {
         offset = operatorSpacing * op;
 
-        OpMultKnob[op] = new RoganMedBlue;
         OpMultKnob[op] = createParam<RoganMedBlue>(Vec(OpMultKnobRootX + offset, OpRow1Y), module,
                                                        Dexter::OP_1_MULT_PARAM + Dexter::NUM_PARAM_GROUPS * op);
         OpMultKnob[op]->snap = true;
         addChild(OpMultKnob[op]);
 
-        OpCoarseKnob[op] = new RoganMedBlue;
         OpCoarseKnob[op] = createParam<RoganMedBlue>(Vec(OpCoarseKnobRootX + offset, OpRow1Y), module,
                                                          Dexter::OP_1_COARSE_PARAM + Dexter::NUM_PARAM_GROUPS * op);
         addChild(OpCoarseKnob[op]);
 
-        OpFineKnob[op] = new RoganMedBlue;
         OpFineKnob[op] = createParam<RoganMedBlue>(Vec(OpFineKnobRootX + offset, OpRow1Y), module,
                                                          Dexter::OP_1_FINE_PARAM + Dexter::NUM_PARAM_GROUPS * op);
         addChild(OpFineKnob[op]);
 
-        OpWaveKnob[op] = new RoganMedPurple;
         OpWaveKnob[op] = createParam<RoganMedPurple>(Vec(OpWaveKnobRootX + offset, OpRow2Y), module,
                                                          Dexter::OP_1_WAVE_PARAM + Dexter::NUM_PARAM_GROUPS * op);
         addChild(OpWaveKnob[op]);
 
-        OpShapeKnob[op] = new RoganMedRed;
         OpShapeKnob[op] = createParam<RoganMedRed>(Vec(OpShapeKnobRootX + offset, OpRow2Y), module,
                                                          Dexter::OP_1_SHAPE_PARAM + Dexter::NUM_PARAM_GROUPS * op);
         addChild(OpShapeKnob[op]);
 
-        OpLevelKnob[op] = new RoganMedGreen;
         OpLevelKnob[op] = createParam<RoganMedGreen>(Vec(OpLevelKnobRootX + offset, OpRow2Y), module,
                                                          Dexter::OP_1_LEVEL_PARAM + Dexter::NUM_PARAM_GROUPS * op);
         addChild(OpLevelKnob[op]);

--- a/src/Terrorform/WavetableEditor/TFormEditorButton.cpp
+++ b/src/Terrorform/WavetableEditor/TFormEditorButton.cpp
@@ -40,9 +40,9 @@ TFormEditorButtonStyleSet::TFormEditorButtonStyleSet() {
 TFormEditorButton::TFormEditorButton() {
     isEnabled = true;
     isHighlighted = false;
+    isFilled = true;
     respondToMouse = true;
     setMode(IDLE_MODE);
-    setFilled(true);
 }
 
 void TFormEditorButton::draw(const DrawArgs& args) {


### PR DESCRIPTION
Both detected by valgrind.
uninitialised values had this log:

```
==869036== Conditional jump or move depends on uninitialised value(s)
==869036==    at 0x21CC383: QuadOsc::setSyncMode(int) (QuadOsc.cpp:601)
==869036==    by 0x21CB239: QuadOsc::QuadOsc() (QuadOsc.cpp:417)
==869036==    by 0x21CD1C1: ScanningQuadOsc::ScanningQuadOsc() (QuadOsc.cpp:732)
==869036==    by 0x2143D90: FourVoiceOPCore::FourVoiceOPCore() (Osc4Core_SIMD.cpp:10)
==869036==    by 0x2124DD9: Dexter::Dexter() (Dexter.cpp:10)
==869036==    by 0x2141F7F: rack::CardinalPluginModel<Dexter, DexterWidget>::createModule() (helpers.hpp:52)
==869036==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036==  Uninitialised value was created by a heap allocation
==869036==    at 0x6E8E013: operator new(unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x2141F74: rack::CardinalPluginModel<Dexter, DexterWidget>::createModule() (helpers.hpp:52)
==869036==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036== 

==869036== Conditional jump or move depends on uninitialised value(s)
==869036==    at 0x7214F40: __powf_fma (e_powf.c:154)
==869036==    by 0x211EB2A: VecAmalgam::calcStepSize() (VecAmalgam.cpp:86)
==869036==    by 0x211EADB: VecAmalgam::setSampleRate(float) (VecAmalgam.cpp:82)
==869036==    by 0x211EA35: VecAmalgam::VecAmalgam() (VecAmalgam.cpp:66)
==869036==    by 0x21127D6: Amalgam::Amalgam() (Amalgam.cpp:3)
==869036==    by 0x211C9B9: rack::CardinalPluginModel<Amalgam, AmalgamWidget>::createModule() (helpers.hpp:52)
==869036==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036==  Uninitialised value was created by a heap allocation
==869036==    at 0x6E8E013: operator new(unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x211C9AE: rack::CardinalPluginModel<Amalgam, AmalgamWidget>::createModule() (helpers.hpp:52)
==869036==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036== 

==869036== Conditional jump or move depends on uninitialised value(s)
==869036==    at 0x7215182: __powf_fma (e_powf.c:160)
==869036==    by 0x211EB2A: VecAmalgam::calcStepSize() (VecAmalgam.cpp:86)
==869036==    by 0x211EADB: VecAmalgam::setSampleRate(float) (VecAmalgam.cpp:82)
==869036==    by 0x211EA35: VecAmalgam::VecAmalgam() (VecAmalgam.cpp:66)
==869036==    by 0x21127D6: Amalgam::Amalgam() (Amalgam.cpp:3)
==869036==    by 0x211C9B9: rack::CardinalPluginModel<Amalgam, AmalgamWidget>::createModule() (helpers.hpp:52)
==869036==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036==  Uninitialised value was created by a heap allocation
==869036==    at 0x6E8E013: operator new(unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x211C9AE: rack::CardinalPluginModel<Amalgam, AmalgamWidget>::createModule() (helpers.hpp:52)
==869036==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036== 

==869036== Conditional jump or move depends on uninitialised value(s)
==869036==    at 0x7214F40: __powf_fma (e_powf.c:154)
==869036==    by 0x211EB2A: VecAmalgam::calcStepSize() (VecAmalgam.cpp:86)
==869036==    by 0x211EADB: VecAmalgam::setSampleRate(float) (VecAmalgam.cpp:82)
==869036==    by 0x2113DE0: Amalgam::Amalgam() (Amalgam.cpp:61)
==869036==    by 0x211C9B9: rack::CardinalPluginModel<Amalgam, AmalgamWidget>::createModule() (helpers.hpp:52)
==869036==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036==  Uninitialised value was created by a heap allocation
==869036==    at 0x6E8E013: operator new(unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x211C9AE: rack::CardinalPluginModel<Amalgam, AmalgamWidget>::createModule() (helpers.hpp:52)
==869036==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036== 

==869036== Conditional jump or move depends on uninitialised value(s)
==869036==    at 0x7215182: __powf_fma (e_powf.c:160)
==869036==    by 0x211EB2A: VecAmalgam::calcStepSize() (VecAmalgam.cpp:86)
==869036==    by 0x211EADB: VecAmalgam::setSampleRate(float) (VecAmalgam.cpp:82)
==869036==    by 0x2113DE0: Amalgam::Amalgam() (Amalgam.cpp:61)
==869036==    by 0x211C9B9: rack::CardinalPluginModel<Amalgam, AmalgamWidget>::createModule() (helpers.hpp:52)
==869036==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036==  Uninitialised value was created by a heap allocation
==869036==    at 0x6E8E013: operator new(unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x211C9AE: rack::CardinalPluginModel<Amalgam, AmalgamWidget>::createModule() (helpers.hpp:52)
==869036==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036== 

==869036== Conditional jump or move depends on uninitialised value(s)
==869036==    at 0x7214F40: __powf_fma (e_powf.c:154)
==869036==    by 0x211EB2A: VecAmalgam::calcStepSize() (VecAmalgam.cpp:86)
==869036==    by 0x211EADB: VecAmalgam::setSampleRate(float) (VecAmalgam.cpp:82)
==869036==    by 0x2116229: Amalgam::onSampleRateChange() (Amalgam.cpp:195)
==869036==    by 0x770346: rack::engine::Module::onSampleRateChange(rack::engine::Module::SampleRateChangeEvent const&) (Module.hpp:409)
==869036==    by 0x24A46CB: rack::engine::Engine::addModule(rack::engine::Module*) (Engine.cpp:616)
==869036==    by 0x6B3B5F: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:495)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036==  Uninitialised value was created by a heap allocation
==869036==    at 0x6E8E013: operator new(unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x211C9AE: rack::CardinalPluginModel<Amalgam, AmalgamWidget>::createModule() (helpers.hpp:52)
==869036==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036== 

==869036== Conditional jump or move depends on uninitialised value(s)
==869036==    at 0x7215182: __powf_fma (e_powf.c:160)
==869036==    by 0x211EB2A: VecAmalgam::calcStepSize() (VecAmalgam.cpp:86)
==869036==    by 0x211EADB: VecAmalgam::setSampleRate(float) (VecAmalgam.cpp:82)
==869036==    by 0x2116229: Amalgam::onSampleRateChange() (Amalgam.cpp:195)
==869036==    by 0x770346: rack::engine::Module::onSampleRateChange(rack::engine::Module::SampleRateChangeEvent const&) (Module.hpp:409)
==869036==    by 0x24A46CB: rack::engine::Engine::addModule(rack::engine::Module*) (Engine.cpp:616)
==869036==    by 0x6B3B5F: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:495)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036==  Uninitialised value was created by a heap allocation
==869036==    at 0x6E8E013: operator new(unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x211C9AE: rack::CardinalPluginModel<Amalgam, AmalgamWidget>::createModule() (helpers.hpp:52)
==869036==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036== 

==869036== Conditional jump or move depends on uninitialised value(s)
==869036==    at 0x21CC383: QuadOsc::setSyncMode(int) (QuadOsc.cpp:601)
==869036==    by 0x21CB239: QuadOsc::QuadOsc() (QuadOsc.cpp:417)
==869036==    by 0x21CD1C1: ScanningQuadOsc::ScanningQuadOsc() (QuadOsc.cpp:732)
==869036==    by 0x21743F6: Terrorform::Terrorform() (Terrorform.cpp:3)
==869036==    by 0x21A411D: rack::CardinalPluginModel<Terrorform, TerrorformWidget>::createModule() (helpers.hpp:52)
==869036==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036==  Uninitialised value was created by a heap allocation
==869036==    at 0x6E8E013: operator new(unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x21A4112: rack::CardinalPluginModel<Terrorform, TerrorformWidget>::createModule() (helpers.hpp:52)
==869036==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036== 

==869036== Conditional jump or move depends on uninitialised value(s)
==869036==    at 0x21EA8C5: TFormEditorButton::setFilled(bool) (TFormEditorButton.cpp:159)
==869036==    by 0x21E9D13: TFormEditorButton::TFormEditorButton() (TFormEditorButton.cpp:45)
==869036==    by 0x21AEB01: TFormEditorButton* rack::createWidget<TFormEditorButton>(rack::math::Vec) (helpers.hpp:53)
==869036==    by 0x21A7666: TFormEditorMainMenu::TFormEditorMainMenu() (TerrorformWaveTableEditor.cpp:221)
==869036==    by 0x21A7DA2: TFormEditor::TFormEditor() (TerrorformWaveTableEditor.cpp:334)
==869036==    by 0x21A0ACB: TFormEditor* rack::createWidget<TFormEditor>(rack::math::Vec) (helpers.hpp:53)
==869036==    by 0x218BB40: TerrorformWidget::TerrorformWidget(Terrorform*) (Terrorform.cpp:1423)
==869036==    by 0x21A42AD: rack::CardinalPluginModel<Terrorform, TerrorformWidget>::createModuleWidget(rack::engine::Module*) (helpers.hpp:70)
==869036==    by 0x6B3ACD: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:491)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036==  Uninitialised value was created by a heap allocation
==869036==    at 0x6E8E013: operator new(unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x21AEAF6: TFormEditorButton* rack::createWidget<TFormEditorButton>(rack::math::Vec) (helpers.hpp:53)
==869036==    by 0x21A7666: TFormEditorMainMenu::TFormEditorMainMenu() (TerrorformWaveTableEditor.cpp:221)
==869036==    by 0x21A7DA2: TFormEditor::TFormEditor() (TerrorformWaveTableEditor.cpp:334)
==869036==    by 0x21A0ACB: TFormEditor* rack::createWidget<TFormEditor>(rack::math::Vec) (helpers.hpp:53)
==869036==    by 0x218BB40: TerrorformWidget::TerrorformWidget(Terrorform*) (Terrorform.cpp:1423)
==869036==    by 0x21A42AD: rack::CardinalPluginModel<Terrorform, TerrorformWidget>::createModuleWidget(rack::engine::Module*) (helpers.hpp:70)
==869036==    by 0x6B3ACD: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:491)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036== 

==869036== Conditional jump or move depends on uninitialised value(s)
==869036==    at 0x21EA8C5: TFormEditorButton::setFilled(bool) (TFormEditorButton.cpp:159)
==869036==    by 0x21E9D13: TFormEditorButton::TFormEditorButton() (TFormEditorButton.cpp:45)
==869036==    by 0x21AEB01: TFormEditorButton* rack::createWidget<TFormEditorButton>(rack::math::Vec) (helpers.hpp:53)
==869036==    by 0x21A76A5: TFormEditorMainMenu::TFormEditorMainMenu() (TerrorformWaveTableEditor.cpp:222)
==869036==    by 0x21A7DA2: TFormEditor::TFormEditor() (TerrorformWaveTableEditor.cpp:334)
==869036==    by 0x21A0ACB: TFormEditor* rack::createWidget<TFormEditor>(rack::math::Vec) (helpers.hpp:53)
==869036==    by 0x218BB40: TerrorformWidget::TerrorformWidget(Terrorform*) (Terrorform.cpp:1423)
==869036==    by 0x21A42AD: rack::CardinalPluginModel<Terrorform, TerrorformWidget>::createModuleWidget(rack::engine::Module*) (helpers.hpp:70)
==869036==    by 0x6B3ACD: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:491)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036==  Uninitialised value was created by a heap allocation
==869036==    at 0x6E8E013: operator new(unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x21AEAF6: TFormEditorButton* rack::createWidget<TFormEditorButton>(rack::math::Vec) (helpers.hpp:53)
==869036==    by 0x21A76A5: TFormEditorMainMenu::TFormEditorMainMenu() (TerrorformWaveTableEditor.cpp:222)
==869036==    by 0x21A7DA2: TFormEditor::TFormEditor() (TerrorformWaveTableEditor.cpp:334)
==869036==    by 0x21A0ACB: TFormEditor* rack::createWidget<TFormEditor>(rack::math::Vec) (helpers.hpp:53)
==869036==    by 0x218BB40: TerrorformWidget::TerrorformWidget(Terrorform*) (Terrorform.cpp:1423)
==869036==    by 0x21A42AD: rack::CardinalPluginModel<Terrorform, TerrorformWidget>::createModuleWidget(rack::engine::Module*) (helpers.hpp:70)
==869036==    by 0x6B3ACD: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:491)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036== 

==869036== Conditional jump or move depends on uninitialised value(s)
==869036==    at 0x21EA8C5: TFormEditorButton::setFilled(bool) (TFormEditorButton.cpp:159)
==869036==    by 0x21E9D13: TFormEditorButton::TFormEditorButton() (TFormEditorButton.cpp:45)
==869036==    by 0x21AEB01: TFormEditorButton* rack::createWidget<TFormEditorButton>(rack::math::Vec) (helpers.hpp:53)
==869036==    by 0x21A76DE: TFormEditorMainMenu::TFormEditorMainMenu() (TerrorformWaveTableEditor.cpp:223)
==869036==    by 0x21A7DA2: TFormEditor::TFormEditor() (TerrorformWaveTableEditor.cpp:334)
==869036==    by 0x21A0ACB: TFormEditor* rack::createWidget<TFormEditor>(rack::math::Vec) (helpers.hpp:53)
==869036==    by 0x218BB40: TerrorformWidget::TerrorformWidget(Terrorform*) (Terrorform.cpp:1423)
==869036==    by 0x21A42AD: rack::CardinalPluginModel<Terrorform, TerrorformWidget>::createModuleWidget(rack::engine::Module*) (helpers.hpp:70)
==869036==    by 0x6B3ACD: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:491)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036==  Uninitialised value was created by a heap allocation
==869036==    at 0x6E8E013: operator new(unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x21AEAF6: TFormEditorButton* rack::createWidget<TFormEditorButton>(rack::math::Vec) (helpers.hpp:53)
==869036==    by 0x21A76DE: TFormEditorMainMenu::TFormEditorMainMenu() (TerrorformWaveTableEditor.cpp:223)
==869036==    by 0x21A7DA2: TFormEditor::TFormEditor() (TerrorformWaveTableEditor.cpp:334)
==869036==    by 0x21A0ACB: TFormEditor* rack::createWidget<TFormEditor>(rack::math::Vec) (helpers.hpp:53)
==869036==    by 0x218BB40: TerrorformWidget::TerrorformWidget(Terrorform*) (Terrorform.cpp:1423)
==869036==    by 0x21A42AD: rack::CardinalPluginModel<Terrorform, TerrorformWidget>::createModuleWidget(rack::engine::Module*) (helpers.hpp:70)
==869036==    by 0x6B3ACD: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:491)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036== 

==869036== Conditional jump or move depends on uninitialised value(s)
==869036==    at 0x21EA8C5: TFormEditorButton::setFilled(bool) (TFormEditorButton.cpp:159)
==869036==    by 0x21E9D13: TFormEditorButton::TFormEditorButton() (TFormEditorButton.cpp:45)
==869036==    by 0x21AEB01: TFormEditorButton* rack::createWidget<TFormEditorButton>(rack::math::Vec) (helpers.hpp:53)
==869036==    by 0x21A7722: TFormEditorMainMenu::TFormEditorMainMenu() (TerrorformWaveTableEditor.cpp:224)
==869036==    by 0x21A7DA2: TFormEditor::TFormEditor() (TerrorformWaveTableEditor.cpp:334)
==869036==    by 0x21A0ACB: TFormEditor* rack::createWidget<TFormEditor>(rack::math::Vec) (helpers.hpp:53)
==869036==    by 0x218BB40: TerrorformWidget::TerrorformWidget(Terrorform*) (Terrorform.cpp:1423)
==869036==    by 0x21A42AD: rack::CardinalPluginModel<Terrorform, TerrorformWidget>::createModuleWidget(rack::engine::Module*) (helpers.hpp:70)
==869036==    by 0x6B3ACD: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:491)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036==  Uninitialised value was created by a heap allocation
==869036==    at 0x6E8E013: operator new(unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x21AEAF6: TFormEditorButton* rack::createWidget<TFormEditorButton>(rack::math::Vec) (helpers.hpp:53)
==869036==    by 0x21A7722: TFormEditorMainMenu::TFormEditorMainMenu() (TerrorformWaveTableEditor.cpp:224)
==869036==    by 0x21A7DA2: TFormEditor::TFormEditor() (TerrorformWaveTableEditor.cpp:334)
==869036==    by 0x21A0ACB: TFormEditor* rack::createWidget<TFormEditor>(rack::math::Vec) (helpers.hpp:53)
==869036==    by 0x218BB40: TerrorformWidget::TerrorformWidget(Terrorform*) (Terrorform.cpp:1423)
==869036==    by 0x21A42AD: rack::CardinalPluginModel<Terrorform, TerrorformWidget>::createModuleWidget(rack::engine::Module*) (helpers.hpp:70)
==869036==    by 0x6B3ACD: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:491)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036== 

==869036== Conditional jump or move depends on uninitialised value(s)
==869036==    at 0x21EA8C5: TFormEditorButton::setFilled(bool) (TFormEditorButton.cpp:159)
==869036==    by 0x21E9D13: TFormEditorButton::TFormEditorButton() (TFormEditorButton.cpp:45)
==869036==    by 0x21AEB01: TFormEditorButton* rack::createWidget<TFormEditorButton>(rack::math::Vec) (helpers.hpp:53)
==869036==    by 0x21A775F: TFormEditorMainMenu::TFormEditorMainMenu() (TerrorformWaveTableEditor.cpp:225)
==869036==    by 0x21A7DA2: TFormEditor::TFormEditor() (TerrorformWaveTableEditor.cpp:334)
==869036==    by 0x21A0ACB: TFormEditor* rack::createWidget<TFormEditor>(rack::math::Vec) (helpers.hpp:53)
==869036==    by 0x218BB40: TerrorformWidget::TerrorformWidget(Terrorform*) (Terrorform.cpp:1423)
==869036==    by 0x21A42AD: rack::CardinalPluginModel<Terrorform, TerrorformWidget>::createModuleWidget(rack::engine::Module*) (helpers.hpp:70)
==869036==    by 0x6B3ACD: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:491)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036==  Uninitialised value was created by a heap allocation
==869036==    at 0x6E8E013: operator new(unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x21AEAF6: TFormEditorButton* rack::createWidget<TFormEditorButton>(rack::math::Vec) (helpers.hpp:53)
==869036==    by 0x21A775F: TFormEditorMainMenu::TFormEditorMainMenu() (TerrorformWaveTableEditor.cpp:225)
==869036==    by 0x21A7DA2: TFormEditor::TFormEditor() (TerrorformWaveTableEditor.cpp:334)
==869036==    by 0x21A0ACB: TFormEditor* rack::createWidget<TFormEditor>(rack::math::Vec) (helpers.hpp:53)
==869036==    by 0x218BB40: TerrorformWidget::TerrorformWidget(Terrorform*) (Terrorform.cpp:1423)
==869036==    by 0x21A42AD: rack::CardinalPluginModel<Terrorform, TerrorformWidget>::createModuleWidget(rack::engine::Module*) (helpers.hpp:70)
==869036==    by 0x6B3ACD: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:491)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036== 

==869036== Conditional jump or move depends on uninitialised value(s)
==869036==    at 0x21EA8C5: TFormEditorButton::setFilled(bool) (TFormEditorButton.cpp:159)
==869036==    by 0x21E9D13: TFormEditorButton::TFormEditorButton() (TFormEditorButton.cpp:45)
==869036==    by 0x21AEB01: TFormEditorButton* rack::createWidget<TFormEditorButton>(rack::math::Vec) (helpers.hpp:53)
==869036==    by 0x21A77A7: TFormEditorMainMenu::TFormEditorMainMenu() (TerrorformWaveTableEditor.cpp:226)
==869036==    by 0x21A7DA2: TFormEditor::TFormEditor() (TerrorformWaveTableEditor.cpp:334)
==869036==    by 0x21A0ACB: TFormEditor* rack::createWidget<TFormEditor>(rack::math::Vec) (helpers.hpp:53)
==869036==    by 0x218BB40: TerrorformWidget::TerrorformWidget(Terrorform*) (Terrorform.cpp:1423)
==869036==    by 0x21A42AD: rack::CardinalPluginModel<Terrorform, TerrorformWidget>::createModuleWidget(rack::engine::Module*) (helpers.hpp:70)
==869036==    by 0x6B3ACD: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:491)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036==  Uninitialised value was created by a heap allocation
==869036==    at 0x6E8E013: operator new(unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x21AEAF6: TFormEditorButton* rack::createWidget<TFormEditorButton>(rack::math::Vec) (helpers.hpp:53)
==869036==    by 0x21A77A7: TFormEditorMainMenu::TFormEditorMainMenu() (TerrorformWaveTableEditor.cpp:226)
==869036==    by 0x21A7DA2: TFormEditor::TFormEditor() (TerrorformWaveTableEditor.cpp:334)
==869036==    by 0x21A0ACB: TFormEditor* rack::createWidget<TFormEditor>(rack::math::Vec) (helpers.hpp:53)
==869036==    by 0x218BB40: TerrorformWidget::TerrorformWidget(Terrorform*) (Terrorform.cpp:1423)
==869036==    by 0x21A42AD: rack::CardinalPluginModel<Terrorform, TerrorformWidget>::createModuleWidget(rack::engine::Module*) (helpers.hpp:70)
==869036==    by 0x6B3ACD: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:491)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036== 

==869036== Conditional jump or move depends on uninitialised value(s)
==869036==    at 0x21EA8C5: TFormEditorButton::setFilled(bool) (TFormEditorButton.cpp:159)
==869036==    by 0x21E9D13: TFormEditorButton::TFormEditorButton() (TFormEditorButton.cpp:45)
==869036==    by 0x21AEB01: TFormEditorButton* rack::createWidget<TFormEditorButton>(rack::math::Vec) (helpers.hpp:53)
==869036==    by 0x21AEA0F: TFormEditorButton* createNewMenuButton<TFormEditorButton>(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::function<void ()> const&, int, int, int, int) (TFormEditorButton.hpp:66)
==869036==    by 0x21A6CC6: TFormPurgeMenu::TFormPurgeMenu() (TerrorformWaveTableEditor.cpp:156)
==869036==    by 0x21AEBC5: TFormPurgeMenu* rack::createWidget<TFormPurgeMenu>(rack::math::Vec) (helpers.hpp:53)
==869036==    by 0x21A7B30: TFormEditorMainMenu::TFormEditorMainMenu() (TerrorformWaveTableEditor.cpp:295)
==869036==    by 0x21A7DA2: TFormEditor::TFormEditor() (TerrorformWaveTableEditor.cpp:334)
==869036==    by 0x21A0ACB: TFormEditor* rack::createWidget<TFormEditor>(rack::math::Vec) (helpers.hpp:53)
==869036==    by 0x218BB40: TerrorformWidget::TerrorformWidget(Terrorform*) (Terrorform.cpp:1423)
==869036==    by 0x21A42AD: rack::CardinalPluginModel<Terrorform, TerrorformWidget>::createModuleWidget(rack::engine::Module*) (helpers.hpp:70)
==869036==    by 0x6B3ACD: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:491)
==869036==  Uninitialised value was created by a heap allocation
==869036==    at 0x6E8E013: operator new(unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x21AEAF6: TFormEditorButton* rack::createWidget<TFormEditorButton>(rack::math::Vec) (helpers.hpp:53)
==869036==    by 0x21AEA0F: TFormEditorButton* createNewMenuButton<TFormEditorButton>(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::function<void ()> const&, int, int, int, int) (TFormEditorButton.hpp:66)
==869036==    by 0x21A6CC6: TFormPurgeMenu::TFormPurgeMenu() (TerrorformWaveTableEditor.cpp:156)
==869036==    by 0x21AEBC5: TFormPurgeMenu* rack::createWidget<TFormPurgeMenu>(rack::math::Vec) (helpers.hpp:53)
==869036==    by 0x21A7B30: TFormEditorMainMenu::TFormEditorMainMenu() (TerrorformWaveTableEditor.cpp:295)
==869036==    by 0x21A7DA2: TFormEditor::TFormEditor() (TerrorformWaveTableEditor.cpp:334)
==869036==    by 0x21A0ACB: TFormEditor* rack::createWidget<TFormEditor>(rack::math::Vec) (helpers.hpp:53)
==869036==    by 0x218BB40: TerrorformWidget::TerrorformWidget(Terrorform*) (Terrorform.cpp:1423)
==869036==    by 0x21A42AD: rack::CardinalPluginModel<Terrorform, TerrorformWidget>::createModuleWidget(rack::engine::Module*) (helpers.hpp:70)
==869036==    by 0x6B3ACD: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:491)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036== 

==869036== Conditional jump or move depends on uninitialised value(s)
==869036==    at 0x21EA8C5: TFormEditorButton::setFilled(bool) (TFormEditorButton.cpp:159)
==869036==    by 0x21E9D13: TFormEditorButton::TFormEditorButton() (TFormEditorButton.cpp:45)
==869036==    by 0x21AEB01: TFormEditorButton* rack::createWidget<TFormEditorButton>(rack::math::Vec) (helpers.hpp:53)
==869036==    by 0x21DAFC0: TFormEditorGrid<8, 8>::TFormEditorGrid() (TFormEditorGrid.hpp:23)
==869036==    by 0x21DA9A1: TFormEditorGrid<8, 8>* rack::createWidget<TFormEditorGrid<8, 8> >(rack::math::Vec) (helpers.hpp:53)
==869036==    by 0x21E168A: TFormEditMainMenu::TFormEditMainMenu() (MainMenu.cpp:50)
==869036==    by 0x21AE559: TFormEditMainMenu* rack::createWidget<TFormEditMainMenu>(rack::math::Vec) (helpers.hpp:53)
==869036==    by 0x21A6314: TFormEditorBankEditMenu::TFormEditorBankEditMenu() (TerrorformWaveTableEditor.cpp:15)
==869036==    by 0x21AEC27: TFormEditorBankEditMenu* rack::createWidget<TFormEditorBankEditMenu>(rack::math::Vec) (helpers.hpp:53)
==869036==    by 0x21A7EAC: TFormEditor::TFormEditor() (TerrorformWaveTableEditor.cpp:340)
==869036==    by 0x21A0ACB: TFormEditor* rack::createWidget<TFormEditor>(rack::math::Vec) (helpers.hpp:53)
==869036==    by 0x218BB40: TerrorformWidget::TerrorformWidget(Terrorform*) (Terrorform.cpp:1423)
==869036==  Uninitialised value was created by a heap allocation
==869036==    at 0x6E8E013: operator new(unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x21AEAF6: TFormEditorButton* rack::createWidget<TFormEditorButton>(rack::math::Vec) (helpers.hpp:53)
==869036==    by 0x21DAFC0: TFormEditorGrid<8, 8>::TFormEditorGrid() (TFormEditorGrid.hpp:23)
==869036==    by 0x21DA9A1: TFormEditorGrid<8, 8>* rack::createWidget<TFormEditorGrid<8, 8> >(rack::math::Vec) (helpers.hpp:53)
==869036==    by 0x21E168A: TFormEditMainMenu::TFormEditMainMenu() (MainMenu.cpp:50)
==869036==    by 0x21AE559: TFormEditMainMenu* rack::createWidget<TFormEditMainMenu>(rack::math::Vec) (helpers.hpp:53)
==869036==    by 0x21A6314: TFormEditorBankEditMenu::TFormEditorBankEditMenu() (TerrorformWaveTableEditor.cpp:15)
==869036==    by 0x21AEC27: TFormEditorBankEditMenu* rack::createWidget<TFormEditorBankEditMenu>(rack::math::Vec) (helpers.hpp:53)
==869036==    by 0x21A7EAC: TFormEditor::TFormEditor() (TerrorformWaveTableEditor.cpp:340)
==869036==    by 0x21A0ACB: TFormEditor* rack::createWidget<TFormEditor>(rack::math::Vec) (helpers.hpp:53)
==869036==    by 0x218BB40: TerrorformWidget::TerrorformWidget(Terrorform*) (Terrorform.cpp:1423)
==869036==    by 0x21A42AD: rack::CardinalPluginModel<Terrorform, TerrorformWidget>::createModuleWidget(rack::engine::Module*) (helpers.hpp:70)
==869036== 
```