### PR TITLE
Enable SIMDE SSE Includes for ARM64 build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 
 # FLAGS will be passed to both the C and C++ compiler
 FLAGS +=
-CFLAGS += -O3 -std=c99
-CXXFLAGS += -O3
+CFLAGS += -O3 -std=c99 -Isrc
+CXXFLAGS += -O3 -Isrc
 
 # Careful about linking to libraries, since you can't assume much about the user's environment and library search path.
 # Static libraries are fine.

--- a/src/Common/DSP/InterpDelay.hpp
+++ b/src/Common/DSP/InterpDelay.hpp
@@ -1,7 +1,7 @@
 #pragma once
 #include <vector>
 #include <cmath>
-#include <pmmintrin.h>
+#include "valley_sse_include.h"
 #define MAX_DELAY_TAP_GROUPS 512
 #define MAX_DELAY_LENGTH 65536
 

--- a/src/Common/SIMD/QuadOsc.hpp
+++ b/src/Common/SIMD/QuadOsc.hpp
@@ -9,7 +9,7 @@
 #ifndef QuadOsc_hpp
 #define QuadOsc_hpp
 
-#include <pmmintrin.h>
+#include "valley_sse_include.h"
 #include <cmath>
 #include <cstdint>
 #include <ctime>

--- a/src/Common/SIMD/SIMDUtilities.hpp
+++ b/src/Common/SIMD/SIMDUtilities.hpp
@@ -7,7 +7,9 @@
 //
 
 #pragma once
-#include <pmmintrin.h>
+
+#include "valley_sse_include.h"
+
 #include <iostream>
 #include <simd/sse_mathfun_extension.h>
 #define VALLEY_1F2 0.5

--- a/src/Interzone/Interzone.hpp
+++ b/src/Interzone/Interzone.hpp
@@ -25,7 +25,7 @@
 #ifndef DSJ_INTERZONE_HPP
 #define DSJ_INTERZONE_HPP
 
-#include <pmmintrin.h>
+#include "valley_sse_include.h"
 #include <iostream>
 #include "../Valley.hpp"
 #include "../ValleyComponents.hpp"

--- a/src/Terrorform/Enhancer.hpp
+++ b/src/Terrorform/Enhancer.hpp
@@ -1,5 +1,7 @@
 #pragma once
-#include <pmmintrin.h>
+
+#include "valley_sse_include.h"
+
 #include <cmath>
 #include <cstdint>
 #include "../Common/SIMD/VecOnePoleFilters.hpp"

--- a/src/Terrorform/TFormSubOsc.hpp
+++ b/src/Terrorform/TFormSubOsc.hpp
@@ -1,5 +1,7 @@
 #pragma once
-#include <pmmintrin.h>
+
+#include "valley_sse_include.h"
+
 #include <cmath>
 #include <cstdint>
 #include "../Common/SIMD/SIMDUtilities.hpp"

--- a/src/valley_sse_include.h
+++ b/src/valley_sse_include.h
@@ -1,0 +1,18 @@
+#ifndef VALLEY_SSE_INCLUDE
+#define VALLEY_SSE_INCLUDE
+
+#if defined(__SSE2__) || defined(_M_AMD64) || defined(_M_X64) ||                                   \
+    (defined(_M_IX86_FP) && _M_IX86_FP >= 2)
+#include <emmintrin.h>
+#include <pmmintrin.h>
+#else
+#if defined(__arm__) || defined(__aarch64__) || defined(__riscv)
+#define SIMDE_ENABLE_NATIVE_ALIASES
+#include "simde/x86/sse2.h"
+#else
+#error Valley requires either X86/SSE2 or ARM architectures.
+#endif
+#endif
+
+#endif
+


### PR DESCRIPTION
1. Add a 'valley_sse_include.h' which includes either intel intrinsics or SIMDE in native aliases mode
2. Replace the includes of intrinsics with that
3. Modify the makefile so src/ is in the header include path for easy of inclusion

Addresses #87