### PR TITLE
One more ARM fix

### DIFF
--- a/src/dsp/shaping/Shaper.hpp
+++ b/src/dsp/shaping/Shaper.hpp
@@ -8,7 +8,8 @@
 
 #pragma once
 
-#include <pmmintrin.h>
+#include "valley_sse_include.h"
+
 #include <cmath>
 #include <cstdint>
 #include <ctime>


### PR DESCRIPTION
The introduction of Shaper.hpp in 11388583305cc5287346fcbc60804580080dccc2 included an intrinsic and not the redirection include, so it re-broke ARM.

Fix