### PR TITLE
Do not use '__decay' reserved keyword (fixes build on latest macOS)

### DIFF
--- a/src/dsp/filters/VecLPG.hpp
+++ b/src/dsp/filters/VecLPG.hpp
@@ -15,7 +15,7 @@
 class VecLPG {
 public:
     __m128 __env;
-    __m128 __attack, __decay;
+    __m128 __attack, __lpdecay;
     __m128 __cutoff, __maxCutoff;
     __m128 __filterSwitch;
     __m128 __vca, __filter, __output;
@@ -85,13 +85,13 @@ public:
         __offset = longScale ? __longOffset : __zeros;
         __m128 x = _mm_mul_ps(_mm_clamp_ps(decay, __zeros, __ones), _mm_add_ps(__scale, __offset));
         x = _mm_sub_ps(_mm_set1_ps(0.4f), _mm_mul_ps(_mm_set1_ps(0.4f), x));
-        __decay = _mm_mul_ps(x, x);
-        __decay = _mm_mul_ps(__decay, x);
-        __decay = _mm_mul_ps(__decay, x);
-        __decay = _mm_mul_ps(__decay, x);
-        __decay = _mm_mul_ps(__decay, x);
-        __decay = _mm_sub_ps(_mm_set1_ps(0.999995f), __decay);
-        __envelope.fallRate = __decay;
+        __lpdecay = _mm_mul_ps(x, x);
+        __lpdecay = _mm_mul_ps(__lpdecay, x);
+        __lpdecay = _mm_mul_ps(__lpdecay, x);
+        __lpdecay = _mm_mul_ps(__lpdecay, x);
+        __lpdecay = _mm_mul_ps(__lpdecay, x);
+        __lpdecay = _mm_sub_ps(_mm_set1_ps(0.999995f), __lpdecay);
+        __envelope.fallRate = __lpdecay;
     }
 
     void setSampleRate(float newSampleRate) {


### PR DESCRIPTION
Fixes the issue reported in https://community.vcvrack.com/t/issue-building-valley-on-macos-ventura-13-5-2/20886

Best to not use variables with "__" prefix as those are meant for the compiler and language specifics, but that would require changing quite some stuff so best you do it when you have time.

For now this PR just allows to build your plugin in new systems.
