### PR TITLE
Fix build with -fsingle-precision-constant

### DIFF
--- a/src/Plateau/Dattorro.cpp
+++ b/src/Plateau/Dattorro.cpp
@@ -159,8 +159,8 @@ void Dattorro1997Tank::setLowCutFrequency(const double frequency) {
 void Dattorro1997Tank::setDiffusion(const double diffusion) {
     assert(diffusion >= 0.0 && diffusion <= 10.0);
 
-    double diffusion1 = scale(diffusion, 0.0, 10.0, 0.0, maxDiffusion1);
-    double diffusion2 = scale(diffusion, 0.0, 10.0, 0.0, maxDiffusion2);
+    double diffusion1 = scale<double>(diffusion, 0.0, 10.0, 0.0, maxDiffusion1);
+    double diffusion2 = scale<double>(diffusion, 0.0, 10.0, 0.0, maxDiffusion2);
 
     leftApf1.setGain(-diffusion1);
     leftApf2.setGain(diffusion2);


### PR DESCRIPTION
The `-fsingle-precision-constant` compiler flag is used to get some performance benefits for systems where 32bit float math is faster than 64bit, it automatically converts all staticly typed doubles into floats which reduces the chance of "double promotion".

This can generate some conflicts at times with templated functions, and is the case for ValleyAudio modules, with the error being:
```
ValleyAudio/src/Plateau/Dattorro.cpp: In member function 'void Dattorro1997Tank::setDiffusion(double)':
ValleyAudio/src/Plateau/Dattorro.cpp:162:71: error: no matching function for call to 'scale(const double&, float, float, float, const double&)'
     double diffusion1 = scale(diffusion, 0.0, 10.0, 0.0, maxDiffusion1);
                                                                       ^
In file included from ValleyAudio/src/Plateau/../dsp/delays/InterpDelay.hpp:12:0,
                 from ValleyAudio/src/Plateau/../dsp/delays/AllpassFilter.hpp:8,
                 from ValleyAudio/src/Plateau/Dattorro.hpp:6,
                 from ValleyAudio/src/Plateau/Dattorro.cpp:1:
ValleyAudio/src/Plateau/../dsp/delays/../../utilities/Utilities.hpp:17:3: note: candidate: template<class T> T scale(T, T, T, T, T)
 T scale(T a, T inMin, T inMax, T outMin, T outMax) {
   ^~~~~
ValleyAudio/src/Plateau/../dsp/delays/../../utilities/Utilities.hpp:17:3: note:   template argument deduction/substitution failed:
ValleyAudio/src/Plateau/Dattorro.cpp:162:71: note:   deduced conflicting types for parameter 'T' ('double' and 'float')
     double diffusion1 = scale(diffusion, 0.0, 10.0, 0.0, maxDiffusion1);

```

The fix is straight forward, we can just specify the function template type, which is more verbose but doesn't hurt anything.
